### PR TITLE
Update the required JDK version to 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <ver.velocity>1.7</ver.velocity>
     <ver.wagon>2.2</ver.wagon>
     <ver.xmlunit>1.4</ver.xmlunit>
-    <jdk.version>1.7</jdk.version>
+    <jdk.version>1.8</jdk.version>
 
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>


### PR DESCRIPTION
Proposed change: set the `jdk-version` in the master `pom.xml` to JDK 1.8, since 1.7 reached end-of-life in April 2015.