### PR TITLE
Fix #191: Add NetBeans specific files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ velocity.log
 bin
 _site
 .sass-cache
+
+nb-configuration.xml
+nbactions.xml


### PR DESCRIPTION
Update root `.gitignore`

`Add nbactions.xml` and `nb-configuration.xml`

Signed-off-by: Jacek Grzebyta <jgrzebyta@users.noreply.github.com>