### PR TITLE
Page remove prefixed filters

### DIFF
--- a/elda-lda/src/main/java/com/epimorphics/lda/core/Param.java
+++ b/elda-lda/src/main/java/com/epimorphics/lda/core/Param.java
@@ -74,7 +74,7 @@ public abstract class Param
 			{ return null; }
 
 		@Override public Param plain() 
-			 { throw new RuntimeException( "cannot make plain a plain parameter: " + p ); }
+			 { return this; }
 		}
 
 	public String lastPropertyOf() {

--- a/elda-lda/src/main/java/com/epimorphics/lda/renderers/common/Page.java
+++ b/elda-lda/src/main/java/com/epimorphics/lda/renderers/common/Page.java
@@ -12,6 +12,7 @@ package com.epimorphics.lda.renderers.common;
 import java.io.StringWriter;
 import java.util.*;
 
+import com.epimorphics.lda.core.Param;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -504,8 +505,11 @@ public class Page extends CommonNodeWrapper
         EldaURL eu = pageURL();
 
         for (NamedParameterValue p : eu.getParameters( true )) {
-            String filterPath = p.name();
+            String key = p.name();
+            Param param = Param.make(shortNameRenderer().shortNameService(), key);
+            String filterPath = param.plain().asString();
             String filterValue = p.toString();
+
             RDFNodeWrapper n = new CommonNodeWrapper( getModelW(), RDFUtil.asRDFNode( filterValue ) );
 
             if (shortNameRenderer().isKnownShortnamePath( filterPath )) {

--- a/elda-lda/src/test/java/com/epimorphics/lda/renderers/common/PageTest.java
+++ b/elda-lda/src/test/java/com/epimorphics/lda/renderers/common/PageTest.java
@@ -53,6 +53,7 @@ public class PageTest
     }};
 
     private Page page;
+    private ResultsModel rm;
 
     /***********************************/
     /* Constructors                    */
@@ -68,7 +69,7 @@ public class PageTest
         final Model apiObjectModel = ModelIOUtils.modelFromTurtle( Fixtures.PAGE_OBJECT_GAMES );
         final Model apiResultsModel = ModelFactory.createUnion( apiMetadataModel, apiObjectModel );
 
-        ResultsModel rm = new ResultsModel( Fixtures.mockResultSet( context, apiResultsModel, apiObjectModel, apiMetadataModel ) );
+        rm = new ResultsModel( Fixtures.mockResultSet( context, apiResultsModel, apiObjectModel, apiMetadataModel ) );
         page = rm.page();
     }
 
@@ -320,6 +321,42 @@ public class PageTest
         Page page1 = rm.page();
         
         assertEquals( "0 results", page1.resultsCountSummary() );
+    }
+
+    @Test
+    public void filterRemovalLinks_ShortNameFilter_ReturnsLink() {
+        Resource res = createPageResource("value=2");
+        Page p = new Page(rm, res);
+        p.initialiseShortNameRenderer(Fixtures.shortNameServiceFixture());
+
+        List<Link> results = p.filterRemovalLinks();
+        assertEquals(1, results.size());
+        assertEquals("<i class='fa fa-minus-circle'></i> value 2", results.get(0).title());
+    }
+
+    @Test
+    public void filterRemovalLinks_PrefixShortNameFilter_ReturnsLink() {
+        Resource res = createPageResource("min-value=2");
+        Page p = new Page(rm, res);
+        p.initialiseShortNameRenderer(Fixtures.shortNameServiceFixture());
+
+        List<Link> results = p.filterRemovalLinks();
+        assertEquals(1, results.size());
+        assertEquals("<i class='fa fa-minus-circle'></i> min-value 2", results.get(0).title());
+    }
+
+    @Test
+    public void filterRemovalLinks_WithoutFilter_DoesNotReturnLink() {
+        Resource res = createPageResource("_properties=value");
+        Page p = new Page(rm, res);
+        p.initialiseShortNameRenderer(Fixtures.shortNameServiceFixture());
+
+        List<Link> results = p.filterRemovalLinks();
+        assertEquals(0, results.size());
+    }
+
+    private Resource createPageResource(String query) {
+        return ResourceFactory.createResource("http://localhost:8080/standalone/hello/games?" + query);
     }
 
     /***********************************/


### PR DESCRIPTION
Add the ability to remove prefixed filters, eg. `min-players`, from an API query using the UI drop down menu.