### PR TITLE
Nested sparql map variable

### DIFF
--- a/elda-lda/src/main/java/com/epimorphics/lda/bindings/Bindings.java
+++ b/elda-lda/src/main/java/com/epimorphics/lda/bindings/Bindings.java
@@ -194,14 +194,7 @@ public class Bindings implements Lookup {
 	private Value getValue(String name) {
 		Value v = getUnexpandedValue(name);
 		if (v == null) return null;
-		
-		if (v.apply != null) {
-			// String spelling = v.spelling();
-			Bindings b = new Bindings(this);
-			// b.put("_param", spelling);
-			String value = mapLookup.getValueString(v.apply, v, b, b.expander);
-			v = v.replaceBy(value);
-		}
+
 		return evaluate(v, new ArrayList<String>());
 	}
 
@@ -284,6 +277,14 @@ public class Bindings implements Lookup {
 	}
 
 	private Value evaluate(Value v, List<String> seen) {
+		if (v.apply != null) {
+			// String spelling = v.spelling();
+			Bindings b = new Bindings(this);
+			// b.put("_param", spelling);
+			String value = mapLookup.getValueString(v.apply, v, b, b.expander);
+			v = v.replaceBy(value);
+		}
+
 		String vs = v.spelling();
 		if (vs == null || vs.indexOf('{') < 0)
 			return v;

--- a/elda-lda/src/main/java/com/epimorphics/lda/bindings/VariableExtractor.java
+++ b/elda-lda/src/main/java/com/epimorphics/lda/bindings/VariableExtractor.java
@@ -9,6 +9,7 @@
 package com.epimorphics.lda.bindings;
 
 
+import static com.epimorphics.lda.specs.SPARQLMapLookup.DEFAULT_PARAM;
 import static com.epimorphics.util.RDFUtils.getStringValue;
 import static com.epimorphics.util.RDFUtils.getResourceValue;
 
@@ -89,7 +90,8 @@ public class VariableExtractor {
 		
 		if (valueNode.isResource()) {
 			Resource vnr = valueNode.asResource();
-			valueString = b.expandVariables(getValueString( ELDA_API.mapFrom, vnr ));
+			valueString = getValueString( ELDA_API.mapFrom, vnr );
+			valueString = valueString == null ? DEFAULT_PARAM : b.expandVariables(valueString);
 			Resource mapResource = getResourceValue( vnr, ELDA_API.mapWith );
 			
 			if (!mapResource.hasProperty(RDF.type, ELDA_API.SPARQLMap)) {

--- a/elda-lda/src/main/java/com/epimorphics/lda/specs/SPARQLMapLookup.java
+++ b/elda-lda/src/main/java/com/epimorphics/lda/specs/SPARQLMapLookup.java
@@ -18,6 +18,8 @@ import com.hp.hpl.jena.query.QuerySolution;
 import com.hp.hpl.jena.query.ResultSet;
 
 public class SPARQLMapLookup implements MapLookup {
+
+	public static final String DEFAULT_PARAM = "param";
 	
 	private final Source ds;
 	private final Map<String, Element> maps;
@@ -53,7 +55,7 @@ public class SPARQLMapLookup implements MapLookup {
 		Element e = maps.get(apply.mapName);
 		
 		String in = e.inName;
-		if (in == null) in = "param";
+		if (in == null) in = DEFAULT_PARAM;
 		b.put(in, v.spelling());
 		
 		String [] result = new String[] {""};


### PR DESCRIPTION
Fixed an issue where API variables which were evaluated by a SPARQL mapping would not take the correct value when nested in the formula of another variable.