### PR TITLE
Filter removal link encoding

### DIFF
--- a/elda-lda/src/main/java/com/epimorphics/lda/renderers/common/Page.java
+++ b/elda-lda/src/main/java/com/epimorphics/lda/renderers/common/Page.java
@@ -27,6 +27,8 @@ import com.hp.hpl.jena.rdf.model.*;
 import com.hp.hpl.jena.sparql.vocabulary.FOAF;
 import com.hp.hpl.jena.vocabulary.DCTerms;
 
+import static org.apache.commons.lang.StringEscapeUtils.escapeHtml;
+
 /**
  * Value object representing the page of results returned by Elda's query
  * processing. Corresponds to a single resource of type <code>api:Page</code>.
@@ -513,7 +515,7 @@ public class Page extends CommonNodeWrapper
             RDFNodeWrapper n = new CommonNodeWrapper( getModelW(), RDFUtil.asRDFNode( filterValue ) );
 
             if (shortNameRenderer().isKnownShortnamePath( filterPath )) {
-                links.add( createRemovalLink( eu, p.name(), p.name(), filterValue, n.getName() ) );
+                links.add( createRemovalLink( eu, p.name(), p.name(), filterValue, escapeHtml(n.getName()) ) );
             }
         }
 

--- a/elda-lda/src/test/java/com/epimorphics/lda/renderers/common/PageTest.java
+++ b/elda-lda/src/test/java/com/epimorphics/lda/renderers/common/PageTest.java
@@ -355,6 +355,17 @@ public class PageTest
         assertEquals(0, results.size());
     }
 
+    @Test
+    public void filterRemovalLinks_withHtmlCharacters_escapesHtml() {
+        Resource res = createPageResource("label=%3Cscript%3Ealert(%27hello%27)%3C%2Fscript%3E");
+        Page p = new Page(rm, res);
+        p.initialiseShortNameRenderer(Fixtures.shortNameServiceFixture());
+
+        List<Link> results = p.filterRemovalLinks();
+        assertEquals(1, results.size());
+        assertEquals("<i class='fa fa-minus-circle'></i> label &lt;script&gt;alert('hello')&lt;/script&gt;", results.get(0).title());
+    }
+
     private Resource createPageResource(String query) {
         return ResourceFactory.createResource("http://localhost:8080/standalone/hello/games?" + query);
     }


### PR DESCRIPTION
Fixed HTML characters in filter removal link not being encoded correctly.