### PR TITLE
Update jersey and jettison dependencies

### DIFF
--- a/dep_tree.txt
+++ b/dep_tree.txt
@@ -1,0 +1,327 @@
+[[1;34mINFO[m] Scanning for projects...
+[[1;34mINFO[m] [1m------------------------------------------------------------------------[m
+[[1;34mINFO[m] [1mReactor Build Order:[m
+[[1;34mINFO[m] 
+[[1;34mINFO[m] elda                                                               [pom]
+[[1;34mINFO[m] elda-lda                                                           [jar]
+[[1;34mINFO[m] elda-assets                                                        [war]
+[[1;34mINFO[m] elda-common                                                        [war]
+[[1;34mINFO[m] elda-standalone                                                    [war]
+[[1;34mINFO[m] elda-testing-webapp                                                [war]
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m----------------------< [0;36mcom.epimorphics.lda:elda[0;1m >----------------------[m
+[[1;34mINFO[m] [1mBuilding elda 2.0.3-SNAPSHOT                                       [1/6][m
+[[1;34mINFO[m] [1m--------------------------------[ pom ]---------------------------------[m
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m--- [0;32mmaven-dependency-plugin:2.8:tree[m [1m(default-cli)[m @ [36melda[0;1m ---[m
+[[1;34mINFO[m] com.epimorphics.lda:elda:pom:2.0.3-SNAPSHOT
+[[1;34mINFO[m] +- org.apache.velocity:velocity:jar:1.7:compile
+[[1;34mINFO[m] |  +- commons-collections:commons-collections:jar:3.2.1:compile
+[[1;34mINFO[m] |  \- commons-lang:commons-lang:jar:2.4:compile
+[[1;34mINFO[m] +- org.apache.lucene:lucene-core:jar:7.1.0:compile
+[[1;34mINFO[m] +- javax.servlet:javax.servlet-api:jar:3.0.1:provided
+[[1;34mINFO[m] +- junit:junit:jar:4.13.2:compile
+[[1;34mINFO[m] |  \- org.hamcrest:hamcrest-core:jar:1.3:compile
+[[1;34mINFO[m] +- org.slf4j:slf4j-api:jar:2.0.17:compile
+[[1;34mINFO[m] +- xmlunit:xmlunit:jar:1.4:compile
+[[1;34mINFO[m] +- org.apache.logging.log4j:log4j-api:jar:2.17.1:compile
+[[1;34mINFO[m] \- org.apache.logging.log4j:log4j-core:jar:2.17.1:compile
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m--------------------< [0;36mcom.epimorphics.lda:elda-lda[0;1m >--------------------[m
+[[1;34mINFO[m] [1mBuilding elda-lda 2.0.3-SNAPSHOT                                   [2/6][m
+[[1;34mINFO[m] [1m--------------------------------[ jar ]---------------------------------[m
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m--- [0;32mmaven-dependency-plugin:2.8:tree[m [1m(default-cli)[m @ [36melda-lda[0;1m ---[m
+[[1;34mINFO[m] com.epimorphics.lda:elda-lda:jar:2.0.3-SNAPSHOT
+[[1;34mINFO[m] +- com.github.jsonld-java:jsonld-java-jena:jar:0.4.1:compile
+[[1;34mINFO[m] |  +- com.github.jsonld-java:jsonld-java:jar:0.4.1:compile
+[[1;34mINFO[m] |  +- xerces:xercesImpl:jar:2.11.0:compile
+[[1;34mINFO[m] |  \- xml-apis:xml-apis:jar:1.4.01:compile
+[[1;34mINFO[m] +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.5:compile
+[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.13.5:compile
+[[1;34mINFO[m] |  \- com.fasterxml.jackson.core:jackson-core:jar:2.13.5:compile
+[[1;34mINFO[m] +- org.apache.velocity:velocity:jar:1.7:compile
+[[1;34mINFO[m] |  +- commons-collections:commons-collections:jar:3.2.1:compile
+[[1;34mINFO[m] |  \- commons-lang:commons-lang:jar:2.4:compile
+[[1;34mINFO[m] +- org.apache.jena:jena-tdb:jar:0.10.1:compile
+[[1;34mINFO[m] |  +- org.apache.jena:jena-arq:jar:2.10.1:compile
+[[1;34mINFO[m] |  +- org.apache.jena:jena-core:jar:2.10.1:compile
+[[1;34mINFO[m] |  \- org.slf4j:slf4j-log4j12:jar:1.6.4:compile
+[[1;34mINFO[m] +- org.apache.jena:jena-core:test-jar:tests:2.11.2:test
+[[1;34mINFO[m] |  \- org.apache.jena:jena-iri:jar:1.0.2:compile
+[[1;34mINFO[m] +- org.apache.jena:jena-arq:test-jar:tests:2.11.2:test
+[[1;34mINFO[m] |  +- org.apache.httpcomponents:httpclient:jar:4.2.6:compile
+[[1;34mINFO[m] |  |  +- org.apache.httpcomponents:httpcore:jar:4.2.5:compile
+[[1;34mINFO[m] |  |  \- commons-codec:commons-codec:jar:1.6:compile
+[[1;34mINFO[m] |  \- org.apache.httpcomponents:httpclient-cache:jar:4.2.6:compile
+[[1;34mINFO[m] +- com.sun.jersey:jersey-core:jar:1.19.4:compile
+[[1;34mINFO[m] |  \- javax.ws.rs:jsr311-api:jar:1.1.1:compile
+[[1;34mINFO[m] +- com.sun.jersey:jersey-servlet:jar:1.19.4:compile
+[[1;34mINFO[m] +- com.sun.jersey:jersey-server:jar:1.19.4:compile
+[[1;34mINFO[m] +- com.sun.jersey:jersey-json:jar:1.19.4:compile
+[[1;34mINFO[m] |  +- com.sun.xml.bind:jaxb-impl:jar:2.2.3-1:compile
+[[1;34mINFO[m] |  |  \- javax.xml.bind:jaxb-api:jar:2.2.2:compile
+[[1;34mINFO[m] |  |     +- javax.xml.stream:stax-api:jar:1.0-2:compile
+[[1;34mINFO[m] |  |     \- javax.activation:activation:jar:1.1:compile
+[[1;34mINFO[m] |  +- org.codehaus.jackson:jackson-core-asl:jar:1.9.2:compile
+[[1;34mINFO[m] |  +- org.codehaus.jackson:jackson-mapper-asl:jar:1.9.2:compile
+[[1;34mINFO[m] |  +- org.codehaus.jackson:jackson-jaxrs:jar:1.9.2:compile
+[[1;34mINFO[m] |  \- org.codehaus.jackson:jackson-xc:jar:1.9.2:compile
+[[1;34mINFO[m] +- org.codehaus.jettison:jettison:jar:1.5.4:compile
+[[1;34mINFO[m] +- org.jmock:jmock-junit4:jar:2.6.0:test
+[[1;34mINFO[m] |  +- org.jmock:jmock:jar:2.6.0:compile
+[[1;34mINFO[m] |  |  \- org.hamcrest:hamcrest-library:jar:1.1:compile
+[[1;34mINFO[m] |  \- junit:junit-dep:jar:4.4:test
+[[1;34mINFO[m] +- com.epimorphics:lib:jar:0.1.6:compile
+[[1;34mINFO[m] |  +- org.apache.jena:apache-jena-libs:pom:2.13.0:compile
+[[1;34mINFO[m] |  \- net.sf.opencsv:opencsv:jar:2.3:compile
+[[1;34mINFO[m] +- org.jmock:jmock-legacy:jar:2.6.0:compile
+[[1;34mINFO[m] |  +- org.objenesis:objenesis:jar:1.0:compile
+[[1;34mINFO[m] |  \- cglib:cglib-nodep:jar:2.1_3:compile
+[[1;34mINFO[m] +- org.mockito:mockito-all:jar:2.0.2-beta:test
+[[1;34mINFO[m] +- org.apache.logging.log4j:log4j-api:jar:2.17.1:compile
+[[1;34mINFO[m] +- org.apache.logging.log4j:log4j-core:jar:2.17.1:compile
+[[1;34mINFO[m] +- org.slf4j:jcl-over-slf4j:jar:2.0.17:compile
+[[1;34mINFO[m] +- org.yaml:snakeyaml:jar:1.33:compile
+[[1;34mINFO[m] +- org.apache.lucene:lucene-core:jar:7.1.0:compile
+[[1;34mINFO[m] +- javax.servlet:javax.servlet-api:jar:3.0.1:provided
+[[1;34mINFO[m] +- junit:junit:jar:4.13.2:compile
+[[1;34mINFO[m] |  \- org.hamcrest:hamcrest-core:jar:1.3:compile
+[[1;34mINFO[m] +- org.slf4j:slf4j-api:jar:2.0.17:compile
+[[1;34mINFO[m] \- xmlunit:xmlunit:jar:1.4:compile
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m------------------< [0;36mcom.epimorphics.lda:elda-assets[0;1m >-------------------[m
+[[1;34mINFO[m] [1mBuilding elda-assets 2.0.3-SNAPSHOT                                [3/6][m
+[[1;34mINFO[m] [1m--------------------------------[ war ]---------------------------------[m
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m--- [0;32mmaven-dependency-plugin:2.8:tree[m [1m(default-cli)[m @ [36melda-assets[0;1m ---[m
+[[1;34mINFO[m] com.epimorphics.lda:elda-assets:war:2.0.3-SNAPSHOT
+[[1;34mINFO[m] +- org.apache.velocity:velocity:jar:1.7:compile
+[[1;34mINFO[m] |  +- commons-collections:commons-collections:jar:3.2.1:compile
+[[1;34mINFO[m] |  \- commons-lang:commons-lang:jar:2.4:compile
+[[1;34mINFO[m] +- org.apache.lucene:lucene-core:jar:7.1.0:compile
+[[1;34mINFO[m] +- javax.servlet:javax.servlet-api:jar:3.0.1:provided
+[[1;34mINFO[m] +- junit:junit:jar:4.13.2:compile
+[[1;34mINFO[m] |  \- org.hamcrest:hamcrest-core:jar:1.3:compile
+[[1;34mINFO[m] +- org.slf4j:slf4j-api:jar:2.0.17:compile
+[[1;34mINFO[m] +- xmlunit:xmlunit:jar:1.4:compile
+[[1;34mINFO[m] +- org.apache.logging.log4j:log4j-api:jar:2.17.1:compile
+[[1;34mINFO[m] \- org.apache.logging.log4j:log4j-core:jar:2.17.1:compile
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m------------------< [0;36mcom.epimorphics.lda:elda-common[0;1m >-------------------[m
+[[1;34mINFO[m] [1mBuilding elda-common 2.0.3-SNAPSHOT                                [4/6][m
+[[1;34mINFO[m] [1m--------------------------------[ war ]---------------------------------[m
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m--- [0;32mmaven-dependency-plugin:2.8:tree[m [1m(default-cli)[m @ [36melda-common[0;1m ---[m
+[[1;34mINFO[m] com.epimorphics.lda:elda-common:war:2.0.3-SNAPSHOT
+[[1;34mINFO[m] +- net.sf.saxon:Saxon-HE:jar:9.5.1-8:compile
+[[1;34mINFO[m] +- net.sourceforge.saxon:saxon:jar:s9api:9.1.0.8:compile
+[[1;34mINFO[m] +- org.apache.velocity:velocity:jar:1.7:compile
+[[1;34mINFO[m] |  +- commons-collections:commons-collections:jar:3.2.1:compile
+[[1;34mINFO[m] |  \- commons-lang:commons-lang:jar:2.4:compile
+[[1;34mINFO[m] +- junit:junit:jar:4.13.2:compile
+[[1;34mINFO[m] |  \- org.hamcrest:hamcrest-core:jar:1.3:compile
+[[1;34mINFO[m] +- com.epimorphics.lda:elda-lda:jar:2.0.3-SNAPSHOT:compile
+[[1;34mINFO[m] |  +- com.github.jsonld-java:jsonld-java-jena:jar:0.4.1:compile
+[[1;34mINFO[m] |  |  +- com.github.jsonld-java:jsonld-java:jar:0.4.1:compile
+[[1;34mINFO[m] |  |  |  +- org.apache.httpcomponents:httpclient:jar:4.2.5:compile
+[[1;34mINFO[m] |  |  |  |  +- org.apache.httpcomponents:httpcore:jar:4.2.4:compile
+[[1;34mINFO[m] |  |  |  |  +- commons-logging:commons-logging:jar:1.1.1:compile
+[[1;34mINFO[m] |  |  |  |  \- commons-codec:commons-codec:jar:1.6:compile
+[[1;34mINFO[m] |  |  |  \- org.apache.httpcomponents:httpclient-cache:jar:4.2.5:compile
+[[1;34mINFO[m] |  |  +- xerces:xercesImpl:jar:2.11.0:compile
+[[1;34mINFO[m] |  |  \- xml-apis:xml-apis:jar:1.4.01:compile
+[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.5:compile
+[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.13.5:compile
+[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.13.5:compile
+[[1;34mINFO[m] |  +- org.apache.jena:jena-tdb:jar:0.10.1:compile
+[[1;34mINFO[m] |  |  +- org.apache.jena:jena-arq:jar:2.10.1:compile
+[[1;34mINFO[m] |  |  +- org.apache.jena:jena-core:jar:2.10.1:compile
+[[1;34mINFO[m] |  |  |  \- org.apache.jena:jena-iri:jar:0.9.6:compile
+[[1;34mINFO[m] |  |  \- org.slf4j:slf4j-log4j12:jar:1.6.4:compile
+[[1;34mINFO[m] |  +- com.sun.jersey:jersey-core:jar:1.19.4:compile
+[[1;34mINFO[m] |  |  \- javax.ws.rs:jsr311-api:jar:1.1.1:compile
+[[1;34mINFO[m] |  +- com.sun.jersey:jersey-servlet:jar:1.19.4:compile
+[[1;34mINFO[m] |  +- com.sun.jersey:jersey-server:jar:1.19.4:compile
+[[1;34mINFO[m] |  +- com.sun.jersey:jersey-json:jar:1.19.4:compile
+[[1;34mINFO[m] |  |  +- com.sun.xml.bind:jaxb-impl:jar:2.2.3-1:compile
+[[1;34mINFO[m] |  |  |  \- javax.xml.bind:jaxb-api:jar:2.2.2:compile
+[[1;34mINFO[m] |  |  |     +- javax.xml.stream:stax-api:jar:1.0-2:compile
+[[1;34mINFO[m] |  |  |     \- javax.activation:activation:jar:1.1:compile
+[[1;34mINFO[m] |  |  +- org.codehaus.jackson:jackson-core-asl:jar:1.9.2:compile
+[[1;34mINFO[m] |  |  +- org.codehaus.jackson:jackson-mapper-asl:jar:1.9.2:compile
+[[1;34mINFO[m] |  |  +- org.codehaus.jackson:jackson-jaxrs:jar:1.9.2:compile
+[[1;34mINFO[m] |  |  \- org.codehaus.jackson:jackson-xc:jar:1.9.2:compile
+[[1;34mINFO[m] |  +- org.codehaus.jettison:jettison:jar:1.5.4:compile
+[[1;34mINFO[m] |  +- com.epimorphics:lib:jar:0.1.6:compile
+[[1;34mINFO[m] |  |  +- org.apache.jena:apache-jena-libs:pom:2.13.0:compile
+[[1;34mINFO[m] |  |  \- net.sf.opencsv:opencsv:jar:2.3:compile
+[[1;34mINFO[m] |  +- org.jmock:jmock-legacy:jar:2.6.0:compile
+[[1;34mINFO[m] |  |  +- org.jmock:jmock:jar:2.6.0:compile
+[[1;34mINFO[m] |  |  |  \- org.hamcrest:hamcrest-library:jar:1.1:compile
+[[1;34mINFO[m] |  |  +- org.objenesis:objenesis:jar:1.0:compile
+[[1;34mINFO[m] |  |  \- cglib:cglib-nodep:jar:2.1_3:compile
+[[1;34mINFO[m] |  +- org.slf4j:jcl-over-slf4j:jar:2.0.17:compile
+[[1;34mINFO[m] |  \- org.yaml:snakeyaml:jar:1.33:compile
+[[1;34mINFO[m] +- org.apache.lucene:lucene-core:jar:7.1.0:compile
+[[1;34mINFO[m] +- javax.servlet:javax.servlet-api:jar:3.0.1:provided
+[[1;34mINFO[m] +- org.slf4j:slf4j-api:jar:2.0.17:compile
+[[1;34mINFO[m] +- xmlunit:xmlunit:jar:1.4:compile
+[[1;34mINFO[m] +- org.apache.logging.log4j:log4j-api:jar:2.17.1:compile
+[[1;34mINFO[m] \- org.apache.logging.log4j:log4j-core:jar:2.17.1:compile
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m----------------< [0;36mcom.epimorphics.lda:elda-standalone[0;1m >-----------------[m
+[[1;34mINFO[m] [1mBuilding elda-standalone 2.0.3-SNAPSHOT                            [5/6][m
+[[1;34mINFO[m] [1m--------------------------------[ war ]---------------------------------[m
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m--- [0;32mmaven-dependency-plugin:2.8:tree[m [1m(default-cli)[m @ [36melda-standalone[0;1m ---[m
+[[1;34mINFO[m] com.epimorphics.lda:elda-standalone:war:2.0.3-SNAPSHOT
+[[1;34mINFO[m] +- org.apache.tomcat.embed:tomcat-embed-core:jar:7.0.94:provided
+[[1;34mINFO[m] |  \- org.apache.tomcat:tomcat-annotations-api:jar:7.0.94:provided
+[[1;34mINFO[m] +- org.apache.tomcat.embed:tomcat-embed-logging-log4j:jar:7.0.94:provided
+[[1;34mINFO[m] +- org.apache.tomcat.embed:tomcat-embed-jasper:jar:7.0.94:provided
+[[1;34mINFO[m] |  +- org.apache.tomcat.embed:tomcat-embed-el:jar:7.0.94:provided
+[[1;34mINFO[m] |  \- org.eclipse.jdt.core.compiler:ecj:jar:4.4.2:provided
+[[1;34mINFO[m] +- com.epimorphics.lda:elda-assets:war:2.0.3-SNAPSHOT:compile
+[[1;34mINFO[m] +- com.epimorphics.lda:elda-lda:jar:2.0.3-SNAPSHOT:compile
+[[1;34mINFO[m] |  +- com.github.jsonld-java:jsonld-java-jena:jar:0.4.1:compile
+[[1;34mINFO[m] |  |  +- com.github.jsonld-java:jsonld-java:jar:0.4.1:compile
+[[1;34mINFO[m] |  |  |  +- org.apache.httpcomponents:httpclient:jar:4.2.5:compile
+[[1;34mINFO[m] |  |  |  |  +- org.apache.httpcomponents:httpcore:jar:4.2.4:compile
+[[1;34mINFO[m] |  |  |  |  +- commons-logging:commons-logging:jar:1.1.1:compile
+[[1;34mINFO[m] |  |  |  |  \- commons-codec:commons-codec:jar:1.6:compile
+[[1;34mINFO[m] |  |  |  \- org.apache.httpcomponents:httpclient-cache:jar:4.2.5:compile
+[[1;34mINFO[m] |  |  +- xerces:xercesImpl:jar:2.11.0:compile
+[[1;34mINFO[m] |  |  \- xml-apis:xml-apis:jar:1.4.01:compile
+[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.5:compile
+[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.13.5:compile
+[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.13.5:compile
+[[1;34mINFO[m] |  +- org.apache.jena:jena-tdb:jar:0.10.1:compile
+[[1;34mINFO[m] |  |  +- org.apache.jena:jena-arq:jar:2.10.1:compile
+[[1;34mINFO[m] |  |  +- org.apache.jena:jena-core:jar:2.10.1:compile
+[[1;34mINFO[m] |  |  |  \- org.apache.jena:jena-iri:jar:0.9.6:compile
+[[1;34mINFO[m] |  |  \- org.slf4j:slf4j-log4j12:jar:1.6.4:compile
+[[1;34mINFO[m] |  +- com.sun.jersey:jersey-core:jar:1.19.4:compile
+[[1;34mINFO[m] |  |  \- javax.ws.rs:jsr311-api:jar:1.1.1:compile
+[[1;34mINFO[m] |  +- com.sun.jersey:jersey-servlet:jar:1.19.4:compile
+[[1;34mINFO[m] |  +- com.sun.jersey:jersey-server:jar:1.19.4:compile
+[[1;34mINFO[m] |  +- com.sun.jersey:jersey-json:jar:1.19.4:compile
+[[1;34mINFO[m] |  |  +- com.sun.xml.bind:jaxb-impl:jar:2.2.3-1:compile
+[[1;34mINFO[m] |  |  |  \- javax.xml.bind:jaxb-api:jar:2.2.2:compile
+[[1;34mINFO[m] |  |  |     +- javax.xml.stream:stax-api:jar:1.0-2:compile
+[[1;34mINFO[m] |  |  |     \- javax.activation:activation:jar:1.1:compile
+[[1;34mINFO[m] |  |  +- org.codehaus.jackson:jackson-core-asl:jar:1.9.2:compile
+[[1;34mINFO[m] |  |  +- org.codehaus.jackson:jackson-mapper-asl:jar:1.9.2:compile
+[[1;34mINFO[m] |  |  +- org.codehaus.jackson:jackson-jaxrs:jar:1.9.2:compile
+[[1;34mINFO[m] |  |  \- org.codehaus.jackson:jackson-xc:jar:1.9.2:compile
+[[1;34mINFO[m] |  +- org.codehaus.jettison:jettison:jar:1.5.4:compile
+[[1;34mINFO[m] |  +- com.epimorphics:lib:jar:0.1.6:compile
+[[1;34mINFO[m] |  |  +- org.apache.jena:apache-jena-libs:pom:2.13.0:compile
+[[1;34mINFO[m] |  |  \- net.sf.opencsv:opencsv:jar:2.3:compile
+[[1;34mINFO[m] |  +- org.jmock:jmock-legacy:jar:2.6.0:compile
+[[1;34mINFO[m] |  |  +- org.jmock:jmock:jar:2.6.0:compile
+[[1;34mINFO[m] |  |  |  \- org.hamcrest:hamcrest-library:jar:1.1:compile
+[[1;34mINFO[m] |  |  +- org.objenesis:objenesis:jar:1.0:compile
+[[1;34mINFO[m] |  |  \- cglib:cglib-nodep:jar:2.1_3:compile
+[[1;34mINFO[m] |  +- org.slf4j:jcl-over-slf4j:jar:2.0.17:compile
+[[1;34mINFO[m] |  \- org.yaml:snakeyaml:jar:1.33:compile
+[[1;34mINFO[m] +- junit:junit:jar:4.13.2:compile
+[[1;34mINFO[m] |  \- org.hamcrest:hamcrest-core:jar:1.3:compile
+[[1;34mINFO[m] +- org.apache.velocity:velocity:jar:1.7:compile
+[[1;34mINFO[m] |  +- commons-collections:commons-collections:jar:3.2.1:compile
+[[1;34mINFO[m] |  \- commons-lang:commons-lang:jar:2.4:compile
+[[1;34mINFO[m] +- org.apache.lucene:lucene-core:jar:7.1.0:compile
+[[1;34mINFO[m] +- javax.servlet:javax.servlet-api:jar:3.0.1:provided
+[[1;34mINFO[m] +- org.slf4j:slf4j-api:jar:2.0.17:compile
+[[1;34mINFO[m] +- xmlunit:xmlunit:jar:1.4:compile
+[[1;34mINFO[m] +- org.apache.logging.log4j:log4j-api:jar:2.17.1:compile
+[[1;34mINFO[m] \- org.apache.logging.log4j:log4j-core:jar:2.17.1:compile
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m--------------< [0;36mcom.epimorphics.lda:elda-testing-webapp[0;1m >---------------[m
+[[1;34mINFO[m] [1mBuilding elda-testing-webapp 2.0.3-SNAPSHOT                        [6/6][m
+[[1;34mINFO[m] [1m--------------------------------[ war ]---------------------------------[m
+[[1;34mINFO[m] 
+[[1;34mINFO[m] [1m--- [0;32mmaven-dependency-plugin:2.8:tree[m [1m(default-cli)[m @ [36melda-testing-webapp[0;1m ---[m
+[[1;34mINFO[m] com.epimorphics.lda:elda-testing-webapp:war:2.0.3-SNAPSHOT
+[[1;34mINFO[m] +- org.apache.tomcat.embed:tomcat-embed-core:jar:7.0.94:provided
+[[1;34mINFO[m] |  \- org.apache.tomcat:tomcat-annotations-api:jar:7.0.94:provided
+[[1;34mINFO[m] +- org.apache.tomcat.embed:tomcat-embed-logging-log4j:jar:7.0.94:provided
+[[1;34mINFO[m] +- org.apache.tomcat.embed:tomcat-embed-jasper:jar:7.0.94:provided
+[[1;34mINFO[m] |  +- org.apache.tomcat.embed:tomcat-embed-el:jar:7.0.94:provided
+[[1;34mINFO[m] |  \- org.eclipse.jdt.core.compiler:ecj:jar:4.4.2:provided
+[[1;34mINFO[m] +- com.sun.jersey.contribs:jersey-multipart:jar:1.19.4:compile
+[[1;34mINFO[m] |  +- org.jvnet.mimepull:mimepull:jar:1.9.3:compile
+[[1;34mINFO[m] |  \- com.sun.jersey:jersey-core:jar:1.19.4:compile
+[[1;34mINFO[m] |     \- javax.ws.rs:jsr311-api:jar:1.1.1:compile
+[[1;34mINFO[m] +- commons-beanutils:commons-beanutils:jar:1.11.0:compile
+[[1;34mINFO[m] |  +- commons-logging:commons-logging:jar:1.3.5:compile
+[[1;34mINFO[m] |  \- commons-collections:commons-collections:jar:3.2.2:compile
+[[1;34mINFO[m] +- com.sun.jersey:jersey-client:jar:1.19.4:compile
+[[1;34mINFO[m] +- com.sun.jersey.contribs:jersey-apache-client:jar:1.19.4:test
+[[1;34mINFO[m] |  \- commons-httpclient:commons-httpclient:jar:3.1:test
+[[1;34mINFO[m] +- com.epimorphics.lda:elda-lda:jar:2.0.3-SNAPSHOT:compile
+[[1;34mINFO[m] |  +- com.github.jsonld-java:jsonld-java-jena:jar:0.4.1:compile
+[[1;34mINFO[m] |  |  +- com.github.jsonld-java:jsonld-java:jar:0.4.1:compile
+[[1;34mINFO[m] |  |  |  \- org.apache.httpcomponents:httpclient-cache:jar:4.2.5:compile
+[[1;34mINFO[m] |  |  +- xerces:xercesImpl:jar:2.11.0:compile
+[[1;34mINFO[m] |  |  \- xml-apis:xml-apis:jar:1.4.01:compile
+[[1;34mINFO[m] |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.5:compile
+[[1;34mINFO[m] |  |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.13.5:compile
+[[1;34mINFO[m] |  |  \- com.fasterxml.jackson.core:jackson-core:jar:2.13.5:compile
+[[1;34mINFO[m] |  +- org.apache.jena:jena-tdb:jar:0.10.1:compile
+[[1;34mINFO[m] |  |  +- org.apache.jena:jena-arq:jar:2.10.1:compile
+[[1;34mINFO[m] |  |  +- org.apache.jena:jena-core:jar:2.10.1:compile
+[[1;34mINFO[m] |  |  |  \- org.apache.jena:jena-iri:jar:0.9.6:compile
+[[1;34mINFO[m] |  |  \- org.slf4j:slf4j-log4j12:jar:1.6.4:compile
+[[1;34mINFO[m] |  +- com.sun.jersey:jersey-servlet:jar:1.19.4:compile
+[[1;34mINFO[m] |  +- com.sun.jersey:jersey-server:jar:1.19.4:compile
+[[1;34mINFO[m] |  +- com.sun.jersey:jersey-json:jar:1.19.4:compile
+[[1;34mINFO[m] |  |  +- com.sun.xml.bind:jaxb-impl:jar:2.2.3-1:compile
+[[1;34mINFO[m] |  |  |  \- javax.xml.bind:jaxb-api:jar:2.2.2:compile
+[[1;34mINFO[m] |  |  |     +- javax.xml.stream:stax-api:jar:1.0-2:compile
+[[1;34mINFO[m] |  |  |     \- javax.activation:activation:jar:1.1:compile
+[[1;34mINFO[m] |  |  +- org.codehaus.jackson:jackson-core-asl:jar:1.9.2:compile
+[[1;34mINFO[m] |  |  +- org.codehaus.jackson:jackson-mapper-asl:jar:1.9.2:compile
+[[1;34mINFO[m] |  |  +- org.codehaus.jackson:jackson-jaxrs:jar:1.9.2:compile
+[[1;34mINFO[m] |  |  \- org.codehaus.jackson:jackson-xc:jar:1.9.2:compile
+[[1;34mINFO[m] |  +- org.codehaus.jettison:jettison:jar:1.5.4:compile
+[[1;34mINFO[m] |  +- com.epimorphics:lib:jar:0.1.6:compile
+[[1;34mINFO[m] |  |  +- org.apache.jena:apache-jena-libs:pom:2.13.0:compile
+[[1;34mINFO[m] |  |  \- net.sf.opencsv:opencsv:jar:2.3:compile
+[[1;34mINFO[m] |  +- org.jmock:jmock-legacy:jar:2.6.0:compile
+[[1;34mINFO[m] |  |  +- org.jmock:jmock:jar:2.6.0:compile
+[[1;34mINFO[m] |  |  |  \- org.hamcrest:hamcrest-library:jar:1.1:compile
+[[1;34mINFO[m] |  |  +- org.objenesis:objenesis:jar:1.0:compile
+[[1;34mINFO[m] |  |  \- cglib:cglib-nodep:jar:2.1_3:compile
+[[1;34mINFO[m] |  +- org.slf4j:jcl-over-slf4j:jar:2.0.17:compile
+[[1;34mINFO[m] |  \- org.yaml:snakeyaml:jar:1.33:compile
+[[1;34mINFO[m] +- com.epimorphics.lda:elda-lda:jar:sources:2.0.3-SNAPSHOT:compile
+[[1;34mINFO[m] +- junit:junit:jar:4.13.2:compile
+[[1;34mINFO[m] |  \- org.hamcrest:hamcrest-core:jar:1.3:compile
+[[1;34mINFO[m] +- com.epimorphics.lda:elda-lda:test-jar:tests:2.0.3-SNAPSHOT:test
+[[1;34mINFO[m] +- org.apache.httpcomponents:httpclient:jar:4.5.14:compile
+[[1;34mINFO[m] |  +- org.apache.httpcomponents:httpcore:jar:4.4.16:compile
+[[1;34mINFO[m] |  \- commons-codec:commons-codec:jar:1.11:compile
+[[1;34mINFO[m] +- org.apache.velocity:velocity:jar:1.7:compile
+[[1;34mINFO[m] |  \- commons-lang:commons-lang:jar:2.4:compile
+[[1;34mINFO[m] +- org.apache.lucene:lucene-core:jar:7.1.0:compile
+[[1;34mINFO[m] +- javax.servlet:javax.servlet-api:jar:3.0.1:provided
+[[1;34mINFO[m] +- org.slf4j:slf4j-api:jar:2.0.17:compile
+[[1;34mINFO[m] +- xmlunit:xmlunit:jar:1.4:compile
+[[1;34mINFO[m] +- org.apache.logging.log4j:log4j-api:jar:2.17.1:compile
+[[1;34mINFO[m] \- org.apache.logging.log4j:log4j-core:jar:2.17.1:compile
+[[1;34mINFO[m] [1m------------------------------------------------------------------------[m
+[[1;34mINFO[m] [1mReactor Summary for elda 2.0.3-SNAPSHOT:[m
+[[1;34mINFO[m] 
+[[1;34mINFO[m] elda ............................................... [1;32mSUCCESS[m [  0.350 s]
+[[1;34mINFO[m] elda-lda ........................................... [1;32mSUCCESS[m [  0.318 s]
+[[1;34mINFO[m] elda-assets ........................................ [1;32mSUCCESS[m [  0.008 s]
+[[1;34mINFO[m] elda-common ........................................ [1;32mSUCCESS[m [  0.018 s]
+[[1;34mINFO[m] elda-standalone .................................... [1;32mSUCCESS[m [  0.019 s]
+[[1;34mINFO[m] elda-testing-webapp ................................ [1;32mSUCCESS[m [  0.046 s]
+[[1;34mINFO[m] [1m------------------------------------------------------------------------[m
+[[1;34mINFO[m] [1;32mBUILD SUCCESS[m
+[[1;34mINFO[m] [1m------------------------------------------------------------------------[m
+[[1;34mINFO[m] Total time:  1.052 s
+[[1;34mINFO[m] Finished at: 2025-10-16T10:35:57+01:00
+[[1;34mINFO[m] [1m------------------------------------------------------------------------[m

--- a/elda-lda/pom.xml
+++ b/elda-lda/pom.xml
@@ -144,6 +144,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.codehaus.jettison</groupId>
+      <artifactId>jettison</artifactId>
+      <version>1.5.4</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.jmock</groupId>
       <artifactId>jmock-junit4</artifactId>
       <version>2.6.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <ver.junit>4.13.2</ver.junit>
     <ver.log4j>2.17.1</ver.log4j>
     <ver.lucene>7.1.0</ver.lucene>
-  	<ver.jersey>1.18.2</ver.jersey>
+  	<ver.jersey>1.19.4</ver.jersey>
     <ver.servlet-api>3.0.1</ver.servlet-api>
     <ver.slf4j>2.0.17</ver.slf4j>
     <ver.velocity>1.7</ver.velocity>


### PR DESCRIPTION
* Bump jersey 1.18.2 -> 1.19.4
* Override transitive dependency on org.codehaus.jettison:jettison 1.1 -> 1.5.4