### PR TITLE
Remove org.codehaus.jackson artifacts

### DIFF
--- a/elda-lda/pom.xml
+++ b/elda-lda/pom.xml
@@ -141,6 +141,13 @@
       <version>${ver.jersey}</version>
       <type>jar</type>
       <scope>compile</scope>
+      <exclusions>
+        <!-- Exclude org.codehaus.jackson artifacts that are replaced by com.fasterxml.jackson.core artifacts -->
+        <exclusion>
+          <groupId>org.codehaus.jackson</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
* Remove transitive dependency on org.codehaus.jackson in favour of explicitly included com.fasterxml.jackson.core artifacts to address CVEs found in vulnerability scanning