### PR TITLE
Datetime formatting error in JSON renderer

### DIFF
--- a/elda-lda/src/main/java/com/epimorphics/jsonrdf/RDFUtil.java
+++ b/elda-lda/src/main/java/com/epimorphics/jsonrdf/RDFUtil.java
@@ -151,17 +151,21 @@ public class RDFUtil {
      * Returns null if not a supported type
      */
     public static String formatDateTime(Literal l, boolean jsonUsesISOdate) {
-        Object val = getTemporalValue(l);
-        if (val instanceof XSDDateTime) {
-            boolean isDate = l.getDatatype().equals(XSDDatatype.XSDdate);
-            Date date = ((XSDDateTime) val).asCalendar().getTime();
-            if (jsonUsesISOdate) {
-                return dateFormatISO(hasTimeZone(l.getLexicalForm()), isDate).format(date);
+        try {
+            Object val = getTemporalValue(l);
+            if (val instanceof XSDDateTime) {
+                boolean isDate = l.getDatatype().equals(XSDDatatype.XSDdate);
+                Date date = ((XSDDateTime) val).asCalendar().getTime();
+                if (jsonUsesISOdate) {
+                    return dateFormatISO(hasTimeZone(l.getLexicalForm()), isDate).format(date);
+                } else {
+                    return dateFormat(hasTimeZone(l.getLexicalForm()), isDate).format(date);
+                }
             } else {
-                return dateFormat(hasTimeZone(l.getLexicalForm()), isDate).format(date);
+                return null;
             }
-        } else {
-            return null;
+        } catch (DatatypeFormatException e) {
+            return l.getLexicalForm();
         }
     }
 

--- a/elda-lda/src/test/java/com/epimorphics/jsonrdf/TestDateTime.java
+++ b/elda-lda/src/test/java/com/epimorphics/jsonrdf/TestDateTime.java
@@ -100,4 +100,10 @@ public class TestDateTime {
         Literal l = ResourceFactory.createTypedLiteral("1999-05-31Z", XSDDatatype.XSDdate);
         assertEquals("1999-05-31", RDFUtil.formatDateTime(l, true));
     }
+
+    @Test
+    public void testDateTimeInvalidFormat() {
+        Literal l = ResourceFactory.createTypedLiteral("20xx", XSDDatatype.XSDdateTime);
+        assertEquals("20xx", RDFUtil.formatDateTime(l, true));
+    }
 }


### PR DESCRIPTION
Fixes #94 
Render incorrectly formatted dates and datetimes in lexical form.