### PR TITLE
Pagination of result set with bnodes

### DIFF
--- a/elda-lda/src/main/java/com/epimorphics/lda/query/APIQuery.java
+++ b/elda-lda/src/main/java/com/epimorphics/lda/query/APIQuery.java
@@ -783,6 +783,7 @@ public class APIQuery implements VarSupply, WantsMetadata {
 
         q.append(constructBGP(pl));
 
+        q.append("FILTER (!isBlank(").append(SELECT_VAR.name()).append("))\n");
         appendFilterExpressions(pl, q);
 
         if (graphName != null)

--- a/elda-lda/src/test/java/com/epimorphics/lda/endpointspec/tests/TestEndpointHandlesWhere.java
+++ b/elda-lda/src/test/java/com/epimorphics/lda/endpointspec/tests/TestEndpointHandlesWhere.java
@@ -36,7 +36,7 @@ public class TestEndpointHandlesWhere {
         APIEndpointSpec eps = new APIEndpointSpec(a, a, e);
         APIEndpointImpl i = new APIEndpointImpl(eps);
         String q = i.getSelectQuery();
-        if (!q.replaceAll("[\n ]+", " ").matches("SELECT \\?item WHERE \\{ PONDENOME \\} OFFSET 0 LIMIT 10")) {
+        if (!q.replaceAll("[\n ]+", " ").matches("SELECT \\?item WHERE \\{ PONDENOME FILTER \\(!isBlank\\(\\?item\\)\\) \\} OFFSET 0 LIMIT 10")) {
             fail("constructed query '" + q + "'\ndoes not contain api:where clause");
         }
     }


### PR DESCRIPTION
Fixes #214 
* Exclude bnodes from initial query to maintain pagination integrity.